### PR TITLE
update `importlib.find_loader`

### DIFF
--- a/sploitkit/core/entity.py
+++ b/sploitkit/core/entity.py
@@ -2,7 +2,7 @@
 import gc
 import re
 import sys
-from importlib import find_loader
+from importlib.util import find_spec
 from inspect import getfile, getmro
 from shutil import which
 
@@ -237,9 +237,11 @@ class Entity(object):
                 for module in v:
                     if isinstance(module, tuple):
                         module, package = module
+                        found = find_spec(module, package)
                     else:
                         package = module
-                    if find_loader(module) is None:
+                        found = find_spec(module)
+                    if found is None:
                         errors.setdefault("python", [])
                         errors["python"].append(package)
                         cls._enabled = False


### PR DESCRIPTION
`importlib.find_loader` has been deprecated since 3.4.

Ref: https://docs.python.org/3.8/library/importlib.html#importlib.find_loader